### PR TITLE
'if' is a clojure special form

### DIFF
--- a/src/deuce/emacs_lisp.clj
+++ b/src/deuce/emacs_lisp.clj
@@ -1,7 +1,7 @@
 (ns deuce.emacs-lisp
     (require [clojure.core :as c])
     (require [clojure.walk :as walk])
-    (:refer-clojure :exclude [defmacro if and or cond let while]))
+    (:refer-clojure :exclude [defmacro and or cond let while]))
 
 (def t true)
 


### PR DESCRIPTION
while it is desired to have them namespaced, they currently are not and are available in every namespace and cannot be excluded
