### PR TITLE
Not if folder exists, but if content exists

### DIFF
--- a/configure-emacs
+++ b/configure-emacs
@@ -2,7 +2,7 @@
 
 EMACS_TAG=emacs-24.2
 
-test -e emacs || git submodule update --init emacs
+test -z `ls emacs` && git submodule update --init emacs
 cd emacs
 git checkout $EMACS_TAG
 


### PR DESCRIPTION
Trying to run configure-emacs after cloning project will fail because
this was checking if emacs folder exists, which is does because it is
a submodule. Now it checks if there is any content in the emacs folder
instead.
