### PR TITLE
Embed nrepl server as complement to swank-clojure

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,9 @@
             [lein-difftest "2.0.0"]
             [lein-marginalia "0.7.1"]]
   :profiles {:dev {:dependencies [[org.clojure/tools.trace "0.7.5"]
-                                  [swank-clojure "1.4.3"]]}}
+                                  [swank-clojure "1.4.3"]
+                                  [org.clojure/tools.nrepl "0.2.2"]
+                                  [clojure-complete "0.2.2"]]}}
   :resource-paths ["emacs/lisp"]
   :jar-exclusions [#".*\.elc"]
   :java-source-paths ["src"]

--- a/src/deuce/main.clj
+++ b/src/deuce/main.clj
@@ -18,6 +18,12 @@
     ((resolve 'swank.swank/start-repl) port))
   (println "Swank connection opened on" port))
 
+(defn nrepl [port]
+  (require 'clojure.tools.nrepl.server)
+  (with-out-str
+    ((resolve 'clojure.tools.nrepl.server/start-server) :port port))
+  (println "nrepl server listening on" port))
+
 (defn display-state-of-emacs []
   (doseq [frame (frame/frame-list)]
     (println "---------------" frame
@@ -53,6 +59,7 @@
                                         (System/exit 0))
                  (option "batch") (do (el/setq noninteractive true) nil)
                  (option "swank-clojure") (swank 4005)
+                 (option "nrepl") (nrepl 7888)
                  #{"-nw" "--no-window-system,"} (do (el/setq inhibit-window-system true) nil)
                  %) args)]
 


### PR DESCRIPTION
Hi Håkan,

Very exciting to see the progress on deuce!

I'm not sure if this is of any interest, but since I'm using nrepl, I added support for embedding a nrepl server so I can poke around just like with swank-clojure.

Tested using:

```
lein run -q --nrepl
```

On a completely unrelated note, I had to bump the perm gen size with `-XX:MaxPermSize=128M` to be able to run/uberjar deuce, but I guess that's probably something you are aware of, related to the general performance. Also I'm running on `1.7.0_11-b21` on a OSX, and from what I gather you're on `1.8.0`.

Exciting stuff!
